### PR TITLE
Recorded once queries are added to sink

### DIFF
--- a/lib/telemetry/sink.rb
+++ b/lib/telemetry/sink.rb
@@ -37,6 +37,17 @@ class Telemetry
             return subset.any? &blk
           end
         end
+
+        detect_once_method_name = "recorded_#{signal}_once?"
+        send(:define_method, detect_once_method_name) do |&blk|
+          subset = send(subset_method_name)
+
+          if blk.nil?
+            return subset.count == 1
+          else
+            return subset.one? &blk
+          end
+        end
       end
       alias :record :record_macro
     end
@@ -77,6 +88,14 @@ class Telemetry
         return !records.empty?
       else
         return records.any? &blk
+      end
+    end
+
+    def recorded_once?(&blk)
+      if blk.nil?
+        return records.count == 1
+      else
+        return records.one? &blk
       end
     end
 

--- a/test/automated/detect_recorded_once.rb
+++ b/test/automated/detect_recorded_once.rb
@@ -1,0 +1,46 @@
+require_relative 'automated_init'
+
+context "Detect Recorded Telemetry Once" do
+  context "Signal Is Not Recorded" do
+    sink = Telemetry::Controls::Sink.example
+
+    test "With predicate" do
+      refute(sink.recorded_once? { |r| r.signal == :something })
+    end
+
+    test "Without predicate" do
+      refute(sink.recorded_once?)
+    end
+  end
+
+  context "Signal Is Recorded Once" do
+    sink = Telemetry::Controls::Sink.example
+
+    sink.record :something, 'some_time', 'some data'
+
+    test "With predicate" do
+      assert(sink.recorded_once? { |r| r.signal == :something })
+      refute(sink.recorded_once? { |r| r.signal == :something_else })
+    end
+
+    test "Without predicate" do
+      assert(sink.recorded_once?)
+    end
+  end
+
+  context "Signal Is Recorded More Than Once" do
+    sink = Telemetry::Controls::Sink.example
+
+    2.times do
+      sink.record :something, 'some_time', 'some data'
+    end
+
+    test "With predicate" do
+      refute(sink.recorded_once? { |r| r.signal == :something })
+    end
+
+    test "Without predicate" do
+      refute(sink.recorded_once?)
+    end
+  end
+end

--- a/test/automated/one_record.rb
+++ b/test/automated/one_record.rb
@@ -1,0 +1,76 @@
+require_relative 'automated_init'
+
+context "One Recorded Telemetry Signal" do
+  context "Signal Is Not Recorded" do
+    sink = Telemetry::Controls::Sink.example
+
+    test "With predicate" do
+      record = sink.one_record { |r| r.signal == :something }
+
+      assert(record.nil?)
+    end
+
+    test "Without predicate" do
+      record = sink.one_record
+
+      assert(record.nil?)
+    end
+  end
+
+  context "Signal Is Recorded Once" do
+    sink = Telemetry::Controls::Sink.example
+
+    control_record = sink.record(:something, 'some_time', 'some data')
+
+    assert(control_record.instance_of?(Telemetry::Sink::Record))
+
+    test "With predicate" do
+      record = sink.one_record { |r| r.signal == :something }
+      assert(record == control_record)
+
+      record = sink.one_record { |r| r.signal == :something_else }
+      assert(record.nil?)
+    end
+
+    test "Without predicate" do
+      assert(sink.one_record == control_record)
+    end
+  end
+
+  context "Signal Is Recorded More Than Once" do
+    sink = Telemetry::Controls::Sink.example
+
+    record_1 = sink.record(:something, 'some_time', 'some data')
+    record_2 = sink.record(:something, 'some_time', 'other data')
+
+    context "Multiple Records Match" do
+      actuate = proc {
+        sink.one_record { |r| r.signal == :something }
+      }
+
+      test "Raises error" do
+        assert actuate do
+          raises_error?(Telemetry::Sink::Error)
+        end
+      end
+    end
+
+    context "One Record Matches" do
+      record = nil
+
+      actuate = proc {
+        record = sink.one_record { |r| r.data == 'other data' }
+      }
+
+      test "Does not raise error" do
+        refute actuate do
+          raises_error?(Telemetry::Sink::Error)
+        end
+      end
+
+      test "Returns matching record" do
+        assert(record == record_2)
+      end
+    end
+  end
+end

--- a/test/automated/specific_recorded_once.rb
+++ b/test/automated/specific_recorded_once.rb
@@ -1,0 +1,41 @@
+require_relative 'automated_init'
+
+context "Record Specific Telemetry Once" do
+  context "Signal Recorded Once" do
+    sink = Telemetry::Controls::Sink::Macro.example
+
+    time = Telemetry::Controls::Time.example
+
+    sink.record_something time, 'some macro data'
+
+    test "Recorded once (with predicate)" do
+      recorded_once = sink.recorded_something_once? { |r| r.data == 'some macro data' }
+      assert(recorded_once)
+    end
+
+    test "Recorded once (without predicate)" do
+      recorded_once = sink.recorded_something_once?
+      assert(recorded_once)
+    end
+  end
+
+  context "Signal Recorded More Than Once" do
+    sink = Telemetry::Controls::Sink::Macro.example
+
+    time = Telemetry::Controls::Time.example
+
+    2.times do
+      sink.record_something time, 'some macro data'
+    end
+
+    test "Not recorded once (with predicate)" do
+      recorded_once = sink.recorded_something_once? { |r| r.data == 'some macro data' }
+      refute(recorded_once)
+    end
+
+    test "Not recorded once (without predicate)" do
+      recorded_once = sink.recorded_something_once?
+      refute(recorded_once)
+    end
+  end
+end


### PR DESCRIPTION
Recently, I came across a situation in the automated tests for `entity-cache` where I wanted to test that all the data in a single telemetry record matched what was expected. For context, we came across a similar challenge using the messaging writer substitute in tests -- we wanted to test that each attribute of a written message matched some control value. This lead us to implement `writer.one_message` on the writer substitute. This PR is bringing similar semantics to `telemetry`, with the added benefit that the writer substitute can be simplified if it uses the implementation of "get one and only one telemetry record" from this PR.

I was not quite able to fully grasp the semantics of the test prose, or the file naming approach in `test/automated/`. So, the automated tests are deserving of close scrutiny.

Anyways, the gist of what this PR adds:

```ruby
class SomeClass
  module Telemetry
    class Sink < ::Telemetry::Sink
      record :some_signal
    end
  end
end

telemetry_sink = SomeClass::Telemetry::Sink.build


telemetry_sink.record(:some_signal, Clock.now, 'some-value')

assert(telemetry_sink.recorded_once?)
assert(telemetry_sink.recorded_once? { |record| record.data.some_value == 'some-value' })
assert(telemetry_sink.recorded_some_signal_once?
assert(telemetry_sink.recorded_some_signal_once? { |record| record.data.some_value == 'some-value' })


telemetry_sink.record(:other_signal, Clock.now, 'some-value')
telemetry_sink.record(:other_signal, Clock.now, 'some-value')

refute(telemetry_sink.recorded_once?)
refute(telemetry_sink.recorded_once? { |record| record.data.some_value == 'some-value' })
refute(telemetry_sink.recorded_other_signal_once?
refute(telemetry_sink.recorded_other_signal_once? { |record| record.data.some_value == 'some-value' })
```

I am not sure whether "once" is the right word for the method names -- perhaps it should be `recorded_one` instead of `recorded_once`, and `recorded_one_some_signal` instead of `recorded_some_signal_once`. I found myself playing a lot of mental gymnastics with this one; input would be appreciated.